### PR TITLE
Bugfix + review clusters.js

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -160,7 +160,7 @@ class Stats extends EventEmitter {
     fetch(this.statsURI)
       .then(res => {
         if (res.statusCode !== 200) {
-          this.log.error(`Error polling stats: ${res.statusCode} ${res.statusText}`)
+          throw new Error(`HTTP status: ${res.statusCode} ${res.statusText}`)
         }
         return res.text()
       })

--- a/src/stats.js
+++ b/src/stats.js
@@ -159,8 +159,8 @@ class Stats extends EventEmitter {
   pollStats() {
     fetch(this.statsURI)
       .then(res => {
-        if (res.statusCode !== 200) {
-          throw new Error(`HTTP status: ${res.statusCode} ${res.statusText}`)
+        if (res.status !== 200) {
+          throw new Error(`HTTP status: ${res.status} ${res.statusText}`)
         }
         return res.text()
       })


### PR DESCRIPTION
I've been spending entirely too much time in golang lately and gave you a nice bug in `stats.js`  ([`res.statusCode != res.status`](https://github.com/mccv/envoy-curses/compare/art/review-2?expand=1#diff-6635c0bbe87eda053376dbd64f1dab6cL162)) but thanks to ill-considered flow control that fell-through and returned a promise regardless, it didn't manifest.

I might write some tests at some point if you don't object. :)

In any case, fixed that and updated `clusters.js` with `s/let/const` and `fetch` vs. `http`

